### PR TITLE
Connect advocates API to PostgreSQL with Drizzle ORM

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-#DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment
+DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -3,10 +3,6 @@ import { advocates } from "../../../db/schema";
 import { advocateData } from "../../../db/seed/advocates";
 
 export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
-
-  const data = advocateData;
-
+  const data = await db.select().from(advocates);
   return Response.json({ data });
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,20 +1,13 @@
-import { drizzle } from "drizzle-orm/postgres-js";
+import { drizzle, PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
-const setup = () => {
-  if (!process.env.DATABASE_URL) {
-    console.error("DATABASE_URL is not set");
-    return {
-      select: () => ({
-        from: () => [],
-      }),
-    };
-  }
+let db: PostgresJsDatabase | null = null;
 
-  // for query purposes
-  const queryClient = postgres(process.env.DATABASE_URL);
-  const db = drizzle(queryClient);
-  return db;
-};
+if (process.env.DATABASE_URL) {
+  const client = postgres(process.env.DATABASE_URL);
+  db = drizzle(client);
+} else {
+  console.error("DATABASE_URL not set");
+}
 
-export default setup();
+export default db as PostgresJsDatabase;


### PR DESCRIPTION
Changes:

- Configured Postgres using Docker and .env
- Ran initial schema migration with drizzle-kit
- Seeded advocate records using /api/seed endpoint
- Updated /api/advocates to fetch from db instead of static data
